### PR TITLE
Enable Rotating the labels in the circular plot

### DIFF
--- a/src/main/java/eu/hansolo/fx/charts/CircularPlot.java
+++ b/src/main/java/eu/hansolo/fx/charts/CircularPlot.java
@@ -457,7 +457,20 @@ public class CircularPlot extends Region {
 
     private void drawChart() {
         paths.clear();
-
+        
+        // Arbitrarily resizing the chart to make space for the ORTHOGONAL labels
+        TickLabelOrientation currentOrientation = getTickLabelOrientation();
+        if (currentOrientation == TickLabelOrientation.ORTHOGONAL) {
+            chartSize         = size * 0.75;
+            mainLineWidth     = chartSize * 0.045;
+            outgoingLineWidth = chartSize * 0.015;
+            tickMarkWidth     = chartSize * TICK_MARK_WIDTH;
+            chartOffset       = (size - chartSize) * 0.5;
+            innerChartOffset  = chartOffset + chartSize * 0.032;
+            innerChartSize    = chartSize - chartSize * 0.064;
+            centerX           = size * 0.5;
+            centerY           = size * 0.5;
+        }
         ctx.clearRect(0, 0, size, size);
 
         double sum       = items.stream().mapToDouble(PlotItem::getValue).sum();
@@ -520,6 +533,18 @@ public class CircularPlot extends Region {
             cosValue = Math.cos(Math.toRadians(-itemStartAngle - itemAngleRange * 0.5 - 180));
             double itemNamePointX = centerX + chartSize * 0.56 * sinValue;
             double itemNamePointY = centerY + chartSize * 0.56 * cosValue;
+            //Attempt to position the text if it's orthogonal so it won't overlap the chart.
+            switch (currentOrientation) {
+                case ORTHOGONAL:
+                    Font font = Fonts.latoRegular(size * 0.02);
+                    Text measureText = new Text(item.getName());
+                    measureText.setFont(font);
+                    double textWidth = measureText.getLayoutBounds().getWidth();
+                    itemNamePointX += textWidth * 0.33 * sinValue;
+                    itemNamePointY += textWidth * 0.33 * cosValue;
+                default:
+                break;
+            }
             ctx.translate(itemNamePointX, itemNamePointY);
             rotateContextForText(ctx, -itemStartAngle, -itemAngleRange * 0.5 + ANGLE_OFFSET, getTickLabelOrientation());
             ctx.fillText(item.getName(), 0, 0);

--- a/src/main/java/eu/hansolo/fx/charts/CircularPlot.java
+++ b/src/main/java/eu/hansolo/fx/charts/CircularPlot.java
@@ -521,7 +521,7 @@ public class CircularPlot extends Region {
             double itemNamePointX = centerX + chartSize * 0.56 * sinValue;
             double itemNamePointY = centerY + chartSize * 0.56 * cosValue;
             ctx.translate(itemNamePointX, itemNamePointY);
-            rotateContextForText(ctx, -itemStartAngle, -itemAngleRange * 0.5 + ANGLE_OFFSET, TickLabelOrientation.TANGENT);
+            rotateContextForText(ctx, -itemStartAngle, -itemAngleRange * 0.5 + ANGLE_OFFSET, getTickLabelOrientation());
             ctx.fillText(item.getName(), 0, 0);
             ctx.restore();
 


### PR DESCRIPTION
changed the main draw chart function to be able to rotate the labels of the circular chart.
However, I did not look at trying to space the labels so they won't go into the chart or go off the edge of the canvas.