### PR TITLE
Added ability to wrap connecting points on radial charts.

### DIFF
--- a/src/main/java/eu/hansolo/fx/charts/XYPane.java
+++ b/src/main/java/eu/hansolo/fx/charts/XYPane.java
@@ -940,7 +940,8 @@ public class XYPane<T extends XYItem> extends Region implements ChartArea {
         points[points.length - 1] = points[0]; // last point == first point
 
         if (SMOOTH_POLAR == SERIES.getChartType()) {
-            Point[] interpolatedPoints = Helper.subdividePoints(points, 16);
+            //Use the subdividePointsRadial method if wrapping required.
+            Point[] interpolatedPoints = SERIES.isWithWrapping()? Helper.subdividePointsRadial(points, 16):Helper.subdividePoints(points, 16);
             ctx.beginPath();
             ctx.moveTo(interpolatedPoints[0].getX(), interpolatedPoints[0].getY());
             for (int i = 0 ; i < interpolatedPoints.length - 1 ; i++) {

--- a/src/main/java/eu/hansolo/fx/charts/YPane.java
+++ b/src/main/java/eu/hansolo/fx/charts/YPane.java
@@ -382,7 +382,8 @@ public class YPane<T extends YItem> extends Region implements ChartArea {
                     ctx.lineTo(CENTER_X, CENTER_Y - OFFSET - r1 * RANGE);
                     Helper.rotateCtx(ctx, CENTER_X, CENTER_Y, angleStep);
                 });
-                double r2 = ((SERIES.getItems().get(NO_OF_SECTORS - 1).getY() - LOWER_BOUND_Y) / DATA_RANGE);
+                //ADDED resuse first point if wrapping required
+                double r2 = SERIES.isWithWrapping()?((SERIES.getItems().get(0).getY() - LOWER_BOUND_Y) / DATA_RANGE) :((SERIES.getItems().get(NO_OF_SECTORS - 1).getY() - LOWER_BOUND_Y) / DATA_RANGE);
                 ctx.lineTo(CENTER_X, CENTER_Y - OFFSET - r2 * RANGE);
                 ctx.closePath();
                 ctx.fill();
@@ -396,7 +397,9 @@ public class YPane<T extends YItem> extends Region implements ChartArea {
 
                 double x = CENTER_X + (-Math.sin(radAngle) * (CENTER_Y - (0.36239 * size)));
                 double y = CENTER_Y + (+Math.cos(radAngle) * (CENTER_Y - (0.36239 * size)));
-                points.add(new Point(x, y));
+                if(!SERIES.isWithWrapping()){
+                    points.add(new Point(x, y));
+                }
 
                 for (T item : SERIES.getItems()) {
                     double r1 = (CENTER_Y - (CENTER_Y - OFFSET - ((item.getY() - LOWER_BOUND_Y) / DATA_RANGE) * RANGE));
@@ -405,12 +408,12 @@ public class YPane<T extends YItem> extends Region implements ChartArea {
                     points.add(new Point(x, y));
                     radAngle += radAngleStep;
                 }
-                double r3 = (CENTER_Y - (CENTER_Y - OFFSET - ((SERIES.getItems().get(NO_OF_SECTORS - 1).getY() - LOWER_BOUND_Y) / DATA_RANGE) * RANGE));
+                double r3 = (SERIES.isWithWrapping())?(CENTER_Y - (CENTER_Y - OFFSET - ((SERIES.getItems().get(0).getY() - LOWER_BOUND_Y) / DATA_RANGE) * RANGE)) :(CENTER_Y - (CENTER_Y - OFFSET - ((SERIES.getItems().get(NO_OF_SECTORS - 1).getY() - LOWER_BOUND_Y) / DATA_RANGE) * RANGE));
                 x = CENTER_X + (-Math.sin(radAngle) * r3);
                 y = CENTER_Y + (+Math.cos(radAngle) * r3);
                 points.add(new Point(x, y));
 
-                Point[] interpolatedPoints = Helper.subdividePoints(points.toArray(new Point[0]), 16);
+                Point[] interpolatedPoints = (SERIES.isWithWrapping())?Helper.subdividePointsRadial(points.toArray(new Point[0]), 16):Helper.subdividePoints(points.toArray(new Point[0]), 16);
 
                 ctx.beginPath();
                 ctx.moveTo(interpolatedPoints[0].getX(), interpolatedPoints[0].getY());

--- a/src/main/java/eu/hansolo/fx/charts/series/Series.java
+++ b/src/main/java/eu/hansolo/fx/charts/series/Series.java
@@ -74,6 +74,9 @@ public abstract class Series<T extends Item> {
     protected       BooleanProperty                           animated;
     protected       long                                      _animationDuration;
     protected       LongProperty                              animationDuration;
+    //ADDED property to see if wrapping should be used or not by default false. Keeps the previous functionality the same.
+    protected       boolean                                   _withWrapping;
+    protected       BooleanProperty                           withWrapping;
     protected       ChartType                                 chartType;
     protected       ObservableList<T>                         items;
     private         CopyOnWriteArrayList<SeriesEventListener> listeners;
@@ -121,6 +124,7 @@ public abstract class Series<T extends Item> {
         _strokeWidth       = -1;
         _animated          = false;
         _animationDuration = 800;
+        _withWrapping      = false;
         chartType          = TYPE;
         items              = FXCollections.observableArrayList();
         listeners          = new CopyOnWriteArrayList<>();
@@ -398,6 +402,28 @@ public abstract class Series<T extends Item> {
             };
         }
         return animationDuration;
+    }
+
+    // ADDED accessors for the withWrapping boolean value and associated property.
+
+    public boolean isWithWrapping() { return null == withWrapping ? _withWrapping : withWrapping.get(); }
+    public void setWithWrapping(final boolean WITH_WRAPPING) {
+        if (null == withWrapping) {
+            _withWrapping = WITH_WRAPPING;
+            fireSeriesEvent(UPDATE_EVENT);
+        } else {
+            withWrapping.set(WITH_WRAPPING);
+        }
+    }
+    public BooleanProperty withWrappingProperty() {
+        if (null == withWrapping) {
+            withWrapping = new BooleanPropertyBase(_withWrapping) {
+                @Override protected void invalidated() { fireSeriesEvent(UPDATE_EVENT); }
+                @Override public Object getBean() { return Series.this; }
+                @Override public String getName() { return "withWrapping"; }
+            };
+        }
+        return symbolsVisible;
     }
 
     public int getNoOfItems() { return items.size(); }

--- a/src/main/java/eu/hansolo/fx/charts/tools/Helper.java
+++ b/src/main/java/eu/hansolo/fx/charts/tools/Helper.java
@@ -242,6 +242,32 @@ public class Helper {
         Point[] points = POINTS.toArray(new Point[0]);
         return Arrays.asList(subdividePoints(points, SUB_DIVISIONS));
     }
+
+    public static final Point[] subdividePointsRadial(final Point[] POINTS, final int SUB_DIVISIONS){
+        assert POINTS != null;
+        assert POINTS.length >= 3;
+        int    noOfPoints = POINTS.length;
+
+        Point[] subdividedPoints = new Point[((noOfPoints - 1) * SUB_DIVISIONS) + 1];
+
+        double increments = 1.0 / (double) SUB_DIVISIONS;
+
+        for (int i = 0 ; i < noOfPoints - 1 ; i++) {
+            Point p0 = i == 0 ? POINTS[noOfPoints - 2] : POINTS[i - 1];
+            Point p1 = POINTS[i];
+            Point p2 = POINTS[i + 1];
+            Point p3 = (i == (noOfPoints - 2)) ? POINTS[1] : POINTS[i + 2];
+
+            CatmullRom<Point> crs = new CatmullRom<>(p0, p1, p2, p3);
+
+            for (int j = 0 ; j <= SUB_DIVISIONS ; j++) {
+                subdividedPoints[(i * SUB_DIVISIONS) + j] = crs.q(j * increments);
+            }
+        }
+
+        return subdividedPoints;
+    }
+
     public static final Point[] subdividePoints(final Point[] POINTS, final int SUB_DIVISIONS) {
         assert POINTS != null;
         assert POINTS.length >= 3;

--- a/src/test/java/eu/hansolo/fx/charts/RadarChartTest.java
+++ b/src/test/java/eu/hansolo/fx/charts/RadarChartTest.java
@@ -44,8 +44,8 @@ import java.util.Random;
  */
 public class RadarChartTest extends Application {
     private static final Random               RND        = new Random();
-    private static final long                 INTERVAL   = 1_000_000_000l;
-    private static final double               ANIM_TIME  = INTERVAL / 1_000_000;
+    private static final long                 INTERVAL   = 10_000_000_000l;
+    private static final double               ANIM_TIME  = INTERVAL / 10_000_000;
     private static final int                  ELEMENTS   = 30;
     private static final ChartType            CHART_TYPE = ChartType.SMOOTH_RADAR_POLYGON;
     private              YSeries<YChartItem> series1;
@@ -76,7 +76,7 @@ public class RadarChartTest extends Application {
         series1 = new YSeries(item3, CHART_TYPE, new RadialGradient(0, 0, 0, 0, 1, true, CycleMethod.NO_CYCLE, new Stop(0.0, Color.rgb(0, 255, 255, 0.25)), new Stop(0.5, Color.rgb(255, 255, 0, 0.5)), new Stop(1.0, Color.rgb(255, 0, 255, 0.75))), Color.TRANSPARENT);
         series2 = new YSeries(item1, CHART_TYPE, new RadialGradient(0, 0, 0, 0, 1, true, CycleMethod.NO_CYCLE, new Stop(0.0, Color.rgb(255, 0, 0, 0.25)), new Stop(0.5, Color.rgb(255, 255, 0, 0.5)), new Stop(1.0, Color.rgb(0, 200, 0, 0.75))), Color.TRANSPARENT);
         series3 = new YSeries(item2, CHART_TYPE, new RadialGradient(0, 0, 0, 0, 1, true, CycleMethod.NO_CYCLE, new Stop(0.0, Color.rgb(0, 255, 255, 0.25)), new Stop(0.5, Color.rgb(0, 255, 255, 0.5)), new Stop(1.0, Color.rgb(0, 0, 255, 0.75))), Color.TRANSPARENT);
-
+        series2.setWithWrapping(true);
         chart   = new YChart(new YPane(series1, series2, series3));
         chart.setPrefSize(600, 600);
 


### PR DESCRIPTION
RADAR and POLAR charts can now optionally have no step between the
last point and the first point of the data set.

The line from the last data point to the first data point is now correct, and when smoothing is enabled, the smoothing algorithm uses wrapping to correctly create the interpolated points. The differences can be visualized by comparing series2 (which uses wrapping) and the other two series in the RadarChartTest example.