### PR TITLE
Calculate the angle of SunburstChart-Segments relative to the parent.

### DIFF
--- a/src/main/java/eu/hansolo/fx/charts/data/TreeNode.java
+++ b/src/main/java/eu/hansolo/fx/charts/data/TreeNode.java
@@ -197,32 +197,12 @@ public class TreeNode<T extends ChartItem> {
 
     public int getMaxLevel() { return getTreeRoot().stream().map(TreeNode<T>::getDepth).max(Comparator.naturalOrder()).orElse(0); }
 
-    public double getPercentage() {
-        List<TreeNode<T>> siblings = getSiblings();
-        double            sum      = siblings.stream().map(node -> node.getItem()).mapToDouble(T::getValue).sum();
-        return Double.compare(sum, 0) == 0 ? 1.0 : getItem().getValue() / sum;
-    }
-
     public List<TreeNode<T>> getSiblings() { return null == getParent() ? new ArrayList<>() : getParent().getChildren(); }
 
     public List<TreeNode<T>> nodesAtSameLevel() {
         final int LEVEL = getDepth();
         return getTreeRoot().stream().filter(node -> node.getDepth() == LEVEL).collect(Collectors.toList());
     }
-
-    public double getParentAngle() {
-        List<TreeNode> parentList = new ArrayList<>();
-        TreeNode node = TreeNode.this;
-        while (!node.getParent().isRoot()) {
-            node = node.getParent();
-            parentList.add(node);
-        }
-        Collections.reverse(parentList);
-        double parentAngle = 360.0;
-        for (TreeNode n : parentList) { parentAngle = parentAngle * n.getPercentage(); }
-        return parentAngle;
-    }
-
 
     // ******************** Event handling ************************************
     public void setOnTreeNodeEvent(final TreeNodeEventListener LISTENER) { addTreeNodeEventListener(LISTENER); }

--- a/src/test/java/eu/hansolo/fx/charts/SunburstChartTest.java
+++ b/src/test/java/eu/hansolo/fx/charts/SunburstChartTest.java
@@ -74,7 +74,6 @@ public class SunburstChartTest extends Application {
         TreeNode jun = new TreeNode(new ChartItem("Jun", 0.3, PINK_1), second);
         TreeNode jul = new TreeNode(new ChartItem("Jul", 0.7, YELLOW_1), third);
         TreeNode aug = new TreeNode(new ChartItem("Aug", 0.6, YELLOW_1), third);
-        TreeNode sep = new TreeNode(new ChartItem("Sep", 0.1, YELLOW_1), third);
         TreeNode oct = new TreeNode(new ChartItem("Oct", 0.5, GREEN_1), fourth);
         TreeNode nov = new TreeNode(new ChartItem("Nov", 0.4, GREEN_1), fourth);
         TreeNode dec = new TreeNode(new ChartItem("Dec", 0.3, GREEN_1), fourth);
@@ -84,15 +83,7 @@ public class SunburstChartTest extends Application {
         TreeNode week7 = new TreeNode(new ChartItem("Week 7", 0.6, PETROL_2), feb);
         TreeNode week8 = new TreeNode(new ChartItem("Week 8", 0.5, PETROL_2), feb);
 
-        TreeNode week17 = new TreeNode(new ChartItem("Week 17", 1.2, PINK_2), may);
-        TreeNode week18 = new TreeNode(new ChartItem("Week 18", 0.8, PINK_2), may);
-        TreeNode week19 = new TreeNode(new ChartItem("Week 19", 0.6, PINK_2), may);
-        TreeNode week20 = new TreeNode(new ChartItem("Week 20", 0.5, PINK_2), may);
-
-        TreeNode week21 = new TreeNode(new ChartItem("Week 21", 1.2, PINK_2), jun);
-        TreeNode week22 = new TreeNode(new ChartItem("Week 22", 0.8, PINK_2), jun);
-        TreeNode week23 = new TreeNode(new ChartItem("Week 23", 0.6, PINK_2), jun);
-        TreeNode week24 = new TreeNode(new ChartItem("Week 24", 0.5, PINK_2), jun);
+        TreeNode week19 = new TreeNode(new ChartItem("Week 19", 0.3, PINK_2), may);
 
         tree.setOnTreeNodeEvent(e -> {
             EventType type = e.getType();


### PR DESCRIPTION
I am not sure if the described behavior is intended. I think both approaches are viable and depend on the understanding of a sunburst chart/ the use case. Furthermore, I apologize if no such pull-requests are wanted.

#### Problem
The percentage / angle of each segment was calculated relative to all siblings. Therefore, if the sum of all children is smaller to the parent the relation could be misleading.
`segmentPercentage = segment.value / sumOfSiblings`
**For example:** If the value of a parent node is 10 and the parent has one child with the value 1 both segments would have the same size. So I would assume both values are the same.
#### Suggestion
- I suggest that each segment-angle is relative to the parent.
- Assuming the sum of all children is less or equal to the parent's value.
`segmentPercentage = segment.value / parent.value` (`if node.hasParent`)

#### Implementation
- I removed `TreeNode::getPercentage` and `TreeNode::getParentAngle` because in my opinion it does not strongly correlate to the data-structure, but to the specific chart.
- I did not fully dig in the segment drawing details, therefore some calculations may be redundant or irritating
- I removed the invisible extra nodes, because they are not needed any more (which is good I think)
- It probably is not fully matching the code-style
- Changed the example to showcase the new possibilities.