### PR TITLE
Fix minor sunburstchart-bug

### DIFF
--- a/src/main/java/eu/hansolo/fx/charts/SunburstChart.java
+++ b/src/main/java/eu/hansolo/fx/charts/SunburstChart.java
@@ -771,7 +771,7 @@ public class SunburstChart<T extends ChartItem> extends Region {
         String tooltipText = new StringBuilder(NODE.getItem().getName()).append("\n").append(String.format(Locale.US, formatString, ((ChartItem) NODE.getItem()).getValue())).toString();
         Tooltip.install(path, new Tooltip(tooltipText));
 
-        path.setOnMousePressed(new WeakEventHandler<>(e -> NODE.getTreeRoot().fireTreeNodeEvent(new TreeNodeEvent(NODE, EventType.NODE_SELECTED))));
+        path.setOnMousePressed(e -> NODE.getTreeRoot().fireTreeNodeEvent(new TreeNodeEvent(NODE, EventType.NODE_SELECTED)));
 
         return path;
     }


### PR DESCRIPTION
If the `EventHandler` is wrapped in the `WeakEventHandler` nothing prevents the `EventHandler` from being **garbage collected**. Therefore, the TreeNodeEvents  will no longer be fired at some random point in time.
However, removing the `WeakEventHanldler` should not result in memory-leaking, because if the chart is redrawn all segments are cleared, the path will get garbage collected and so the `EventHanlder`.