### PR TITLE
Sunburst

### DIFF
--- a/src/main/java/eu/hansolo/fx/charts/SunburstChart.java
+++ b/src/main/java/eu/hansolo/fx/charts/SunburstChart.java
@@ -18,9 +18,9 @@ package eu.hansolo.fx.charts;
 
 
 import eu.hansolo.fx.charts.data.ChartItem;
-import eu.hansolo.fx.charts.event.EventType;
 import eu.hansolo.fx.charts.event.TreeNodeEvent;
 import eu.hansolo.fx.charts.event.TreeNodeEventListener;
+import eu.hansolo.fx.charts.event.TreeNodeEventType;
 import eu.hansolo.fx.charts.font.Fonts;
 import eu.hansolo.fx.charts.tools.Helper;
 import eu.hansolo.fx.charts.data.TreeNode;
@@ -133,7 +133,7 @@ public class SunburstChart<T extends ChartItem> extends Region {
     private              int                             maxLevel;
     private              Map<Integer, List<TreeNode<T>>> levelMap;
     private              InvalidationListener            sizeListener;
-    private              TreeNodeEventListener           treeNodeListener;
+    private        final TreeNodeEventListener<T>           treeNodeListener;
 
 
 
@@ -162,7 +162,7 @@ public class SunburstChart<T extends ChartItem> extends Region {
         levelMap               = new HashMap<>(8);
         sizeListener           = o -> resize();
         treeNodeListener       = EVENT -> {
-            if(EVENT.getType()!= EventType.NODE_SELECTED){
+            if(EVENT.getType()!= TreeNodeEventType.NODE_SELECTED){
                 redraw();
             }
         };
@@ -649,7 +649,7 @@ public class SunburstChart<T extends ChartItem> extends Region {
 
             double   segmentStartAngle;
             double   segmentEndAngle = 0;
-            TreeNode currentParent   = null;
+            TreeNode<T> currentParent   = null;
 
             for (TreeNode<T> node : nodesAtLevel) {
                 ChartItem segmentData  = node.getItem();
@@ -674,7 +674,7 @@ public class SunburstChart<T extends ChartItem> extends Region {
                         segmentStartAngle =segmentEndAngle;
                     }
                     // The percentage is relative to the parent
-                    segmentPercentage = segmentData.getValue() / ((ChartItem) currentParent.getItem()).getValue();
+                    segmentPercentage = segmentData.getValue() / currentParent.getItem().getValue();
                     segmentAngle      = angles.get(currentParent) * segmentPercentage;
                 }
                 segmentEndAngle = segmentStartAngle + segmentAngle;
@@ -748,7 +748,7 @@ public class SunburstChart<T extends ChartItem> extends Region {
         segmentPane.getChildren().setAll(segments);
     }
 
-    private Path createSegment(final double START_ANGLE, final double END_ANGLE, final double INNER_RADIUS, final double OUTER_RADIUS, final Paint FILL, final Color STROKE, final TreeNode NODE) {
+    private Path createSegment(final double START_ANGLE, final double END_ANGLE, final double INNER_RADIUS, final double OUTER_RADIUS, final Paint FILL, final Color STROKE, final TreeNode<T> NODE) {
         double  startAngleRad = Math.toRadians(START_ANGLE);
         double  endAngleRad   = Math.toRadians(END_ANGLE);
         boolean largeAngle    = Math.abs(END_ANGLE - START_ANGLE) > 180.0;
@@ -784,7 +784,7 @@ public class SunburstChart<T extends ChartItem> extends Region {
         String tooltipText = new StringBuilder(NODE.getItem().getName()).append("\n").append(String.format(Locale.US, formatString, ((ChartItem) NODE.getItem()).getValue())).toString();
         Tooltip.install(path, new Tooltip(tooltipText));
 
-        path.setOnMousePressed(e -> NODE.getTreeRoot().fireTreeNodeEvent(new TreeNodeEvent(NODE, EventType.NODE_SELECTED)));
+        path.setOnMousePressed(e -> NODE.getTreeRoot().fireTreeNodeEvent(new TreeNodeEvent(NODE, TreeNodeEventType.NODE_SELECTED)));
 
         return path;
     }

--- a/src/main/java/eu/hansolo/fx/charts/event/EventType.java
+++ b/src/main/java/eu/hansolo/fx/charts/event/EventType.java
@@ -18,5 +18,4 @@ package eu.hansolo.fx.charts.event;
 
 public enum EventType {
     UPDATE, FINISHED, SELECTED, CONNECTION_SELECTED_FROM, CONNECTION_SELECTED_TO, CONNECTION_SELECTED,
-    PARENT_CHANGED, CHILDREN_CHANGED, NODE_SELECTED // Only used in TreeNode
 }

--- a/src/main/java/eu/hansolo/fx/charts/event/TreeNodeEvent.java
+++ b/src/main/java/eu/hansolo/fx/charts/event/TreeNodeEvent.java
@@ -17,23 +17,24 @@
 package eu.hansolo.fx.charts.event;
 
 
+import eu.hansolo.fx.charts.data.Item;
 import eu.hansolo.fx.charts.data.TreeNode;
 
 
-public class TreeNodeEvent {
-    private final TreeNode  SRC;
-    private final EventType TYPE;
+public class TreeNodeEvent <T extends Item> {
+    private final TreeNode<T>  SRC;
+    private final TreeNodeEventType TYPE;
 
 
     // ******************** Constructors **************************************
-    public TreeNodeEvent(final TreeNode SRC, final EventType TYPE) {
+    public TreeNodeEvent(final TreeNode<T> SRC, final TreeNodeEventType TYPE) {
         this.SRC  = SRC;
         this.TYPE = TYPE;
     }
 
 
     // ******************** Methods *******************************************
-    public TreeNode getSource() { return SRC; }
+    public TreeNode<T> getSource() { return SRC; }
 
-    public EventType getType() { return TYPE; }
+    public TreeNodeEventType getType() { return TYPE; }
 }

--- a/src/main/java/eu/hansolo/fx/charts/event/TreeNodeEventListener.java
+++ b/src/main/java/eu/hansolo/fx/charts/event/TreeNodeEventListener.java
@@ -16,7 +16,9 @@
 
 package eu.hansolo.fx.charts.event;
 
+import eu.hansolo.fx.charts.data.Item;
+
 @FunctionalInterface
-public interface TreeNodeEventListener {
-    void onTreeNodeEvent(final TreeNodeEvent EVENT);
+public interface TreeNodeEventListener <T extends Item> {
+    void onTreeNodeEvent(final TreeNodeEvent<T> EVENT);
 }

--- a/src/main/java/eu/hansolo/fx/charts/event/TreeNodeEventType.java
+++ b/src/main/java/eu/hansolo/fx/charts/event/TreeNodeEventType.java
@@ -1,0 +1,7 @@
+package eu.hansolo.fx.charts.event;
+
+public enum TreeNodeEventType {
+
+  PARENT_CHANGED, CHILDREN_CHANGED, NODE_SELECTED
+
+}

--- a/src/test/java/eu/hansolo/fx/charts/SunburstChartTest.java
+++ b/src/test/java/eu/hansolo/fx/charts/SunburstChartTest.java
@@ -21,6 +21,7 @@ import eu.hansolo.fx.charts.SunburstChart.VisibleData;
 import eu.hansolo.fx.charts.data.ChartItem;
 import eu.hansolo.fx.charts.data.TreeNode;
 import eu.hansolo.fx.charts.event.EventType;
+import eu.hansolo.fx.charts.event.TreeNodeEventType;
 import javafx.application.Application;
 import javafx.collections.ObservableList;
 import javafx.geometry.HPos;
@@ -55,41 +56,41 @@ public class SunburstChartTest extends Application {
 
     private static       int           noOfNodes = 0;
 
-    private TreeNode      tree;
+    private TreeNode<ChartItem>      tree;
     private SunburstChart nonInteractiveSunburstChart;
     private SunburstChart interactiveSunburstChart;
 
     @Override public void init() {
-        tree            = new TreeNode(new ChartItem("ROOT"));
-        TreeNode first  = new TreeNode(new ChartItem("1st", 8.3, PETROL_0), tree);
-        TreeNode second = new TreeNode(new ChartItem("2nd", 2.2, PINK_0), tree);
-        TreeNode third  = new TreeNode(new ChartItem("3rd", 1.4, YELLOW_0), tree);
-        TreeNode fourth = new TreeNode(new ChartItem("4th", 1.2, GREEN_0), tree);
+        tree            = new TreeNode<>(new ChartItem("ROOT"));
+        TreeNode<ChartItem>first  = new TreeNode<>(new ChartItem("1st", 8.3, PETROL_0), tree);
+        TreeNode<ChartItem>second = new TreeNode<>(new ChartItem("2nd", 2.2, PINK_0), tree);
+        TreeNode<ChartItem>third  = new TreeNode<>(new ChartItem("3rd", 1.4, YELLOW_0), tree);
+        TreeNode<ChartItem>fourth = new TreeNode<>(new ChartItem("4th", 1.2, GREEN_0), tree);
 
-        TreeNode jan = new TreeNode(new ChartItem("Jan", 3.5, PETROL_1), first);
-        TreeNode feb = new TreeNode(new ChartItem("Feb", 3.1, PETROL_1), first);
-        TreeNode mar = new TreeNode(new ChartItem("Mar", 1.7, PETROL_1), first);
-        TreeNode apr = new TreeNode(new ChartItem("Apr", 1.1, PINK_1), second);
-        TreeNode may = new TreeNode(new ChartItem("May", 0.8, PINK_1), second);
-        TreeNode jun = new TreeNode(new ChartItem("Jun", 0.3, PINK_1), second);
-        TreeNode jul = new TreeNode(new ChartItem("Jul", 0.7, YELLOW_1), third);
-        TreeNode aug = new TreeNode(new ChartItem("Aug", 0.6, YELLOW_1), third);
-        TreeNode oct = new TreeNode(new ChartItem("Oct", 0.5, GREEN_1), fourth);
-        TreeNode nov = new TreeNode(new ChartItem("Nov", 0.4, GREEN_1), fourth);
-        TreeNode dec = new TreeNode(new ChartItem("Dec", 0.3, GREEN_1), fourth);
+        TreeNode<ChartItem>jan = new TreeNode<>(new ChartItem("Jan", 3.5, PETROL_1), first);
+        TreeNode<ChartItem>feb = new TreeNode<>(new ChartItem("Feb", 3.1, PETROL_1), first);
+        TreeNode<ChartItem>mar = new TreeNode<>(new ChartItem("Mar", 1.7, PETROL_1), first);
+        TreeNode<ChartItem>apr = new TreeNode<>(new ChartItem("Apr", 1.1, PINK_1), second);
+        TreeNode<ChartItem>may = new TreeNode<>(new ChartItem("May", 0.8, PINK_1), second);
+        TreeNode<ChartItem>jun = new TreeNode<>(new ChartItem("Jun", 0.3, PINK_1), second);
+        TreeNode<ChartItem>jul = new TreeNode<>(new ChartItem("Jul", 0.7, YELLOW_1), third);
+        TreeNode<ChartItem>aug = new TreeNode<>(new ChartItem("Aug", 0.6, YELLOW_1), third);
+        TreeNode<ChartItem>oct = new TreeNode<>(new ChartItem("Oct", 0.5, GREEN_1), fourth);
+        TreeNode<ChartItem>nov = new TreeNode<>(new ChartItem("Nov", 0.4, GREEN_1), fourth);
+        TreeNode<ChartItem>dec = new TreeNode<>(new ChartItem("Dec", 0.3, GREEN_1), fourth);
 
-        TreeNode week5 = new TreeNode(new ChartItem("Week 5", 1.2, PETROL_2), feb);
-        TreeNode week6 = new TreeNode(new ChartItem("Week 6", 0.8, PETROL_2), feb);
-        TreeNode week7 = new TreeNode(new ChartItem("Week 7", 0.6, PETROL_2), feb);
-        TreeNode week8 = new TreeNode(new ChartItem("Week 8", 0.5, PETROL_2), feb);
+        TreeNode<ChartItem>week5 = new TreeNode<>(new ChartItem("Week 5", 1.2, PETROL_2), feb);
+        TreeNode<ChartItem>week6 = new TreeNode<>(new ChartItem("Week 6", 0.8, PETROL_2), feb);
+        TreeNode<ChartItem>week7 = new TreeNode<>(new ChartItem("Week 7", 0.6, PETROL_2), feb);
+        TreeNode<ChartItem>week8 = new TreeNode<>(new ChartItem("Week 8", 0.5, PETROL_2), feb);
 
-        TreeNode week19 = new TreeNode(new ChartItem("Week 19", 0.3, PINK_2), may);
+        TreeNode<ChartItem>week19 = new TreeNode<>(new ChartItem("Week 19", 0.3, PINK_2), may);
 
         tree.setOnTreeNodeEvent(e -> {
-            EventType type = e.getType();
-            if (EventType.NODE_SELECTED == type) {
-                TreeNode segment = e.getSource();
-                System.out.println(segment.getItem().getName() + ": " + ((ChartItem) segment.getItem()).getValue());
+            TreeNodeEventType type = e.getType();
+            if (TreeNodeEventType.NODE_SELECTED == type) {
+                TreeNode<ChartItem> segment = e.getSource();
+                System.out.println(segment.getItem().getName() + ": " + segment.getItem().getValue());
             }
         });
 
@@ -145,7 +146,6 @@ public class SunburstChartTest extends Application {
 
         interactiveSunburstChart.setAutoTextColor(true);
 
-        //timer.start();
 
         // Calculate number of nodes
         calcNoOfNodes(nonInteractiveSunburstChart);


### PR DESCRIPTION
All changes mainly concern the `SunburstChart` and the `TreeNode` class and implement most changes suggested in this Issue #32.

1. Simplify `SunburstChart`: Calculation of angles.
  1.1 Merge `centerX/Y` into `center` because they are allways the same 
2. Fix full cirlce: If the chart has only one layer with one item `ArcTo` would not draw a full circle but [nothing](https://github.com/HanSolo/charts/compare/master...jkrude:Sunburst?expand=1#diff-9e74361af8ac1f35ea4e95c399a3b95494db2184bb679f8aa7c6a1e4d48a154cR768).
3. The listener for changes in the tree should not redraw if an item was only selected but not modified.
  3.1. Only a listener on the root is needed because all changes are reported to the [root](https://github.com/HanSolo/charts/compare/master...jkrude:Sunburst?expand=1#diff-9e74361af8ac1f35ea4e95c399a3b95494db2184bb679f8aa7c6a1e4d48a154cR579).
  3.2 It could be considered unsafe removing all [listener](https://github.com/HanSolo/charts/compare/master...jkrude:Sunburst?expand=1#diff-9e74361af8ac1f35ea4e95c399a3b95494db2184bb679f8aa7c6a1e4d48a154cR225)
4. Make `TreeNode` safer and casting-free enforcing generics
5. Move Events for `TreeNodes` to its own `enum` because they were anyway only used by `TreeNodes`

I would further like to decouple a new class `AnimatedChartItem` from `ChartItem`, because animations are visual (and the rest pure data-management) and require a JavaFx context, therefore it is harder to test any class that uses `ChartItem`.
