### PR TITLE
Update logback/slf4j to jpms compatible versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,12 +38,12 @@ dependencies {
     implementation "org.openjfx:javafx-base:${javafxVersion}:${platform}"
     implementation "org.openjfx:javafx-graphics:${javafxVersion}:${platform}"
     implementation "org.openjfx:javafx-controls:${javafxVersion}:${platform}"
-    implementation "org.openjfx:javafx-swing:${javafxVersion}:$platform"
+    implementation "org.openjfx:javafx-swing:${javafxVersion}:${platform}"
     implementation "eu.hansolo:toolbox:17.0.53"
     implementation "eu.hansolo:toolboxfx:17.0.43"
     implementation "eu.hansolo.fx:heatmap:17.0.23"
     implementation "eu.hansolo.fx:countries:17.0.33"
-    implementation "ch.qos.logback:logback-classic:1.2.6"
+    implementation "ch.qos.logback:logback-classic:1.3.9"
 }
 
 jar {

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -11,7 +11,7 @@ module eu.hansolo.fx.charts {
     requires transitive javafx.swing;
 
     // 3rd party
-    requires logback.classic;
+    requires ch.qos.logback.classic;
     requires org.slf4j;
     requires transitive eu.hansolo.toolbox;
     requires transitive eu.hansolo.toolboxfx;


### PR DESCRIPTION
This PR updates logback to a JPMS compatible version to be able to perform jlink when using `requires eu.hansolo.fx.charts;`.

Note, currently when attempting to do a jlink build we get the following error:

```
error: package javax.servlet does not exist
    provides javax.servlet.ServletContainerInitializer with ch.qos.logback.classic.servlet.LogbackServletContainerInitializer;
```

Seems to be tied to logback 1.2.x not being fully JPMS compatible at the time. Seems this was resolved in [1.3.1](https://logback.qos.ch/news.html#1.3.1). 1.3.x and SL4J 2.x should be fully JPMS compatible and therefore resolve this issue. Didn't update it to 1.4.x since that introduces the big jakarta transition.