### PR TITLE
Small changes to match other packages

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,9 +44,20 @@ dependencies {
     implementation "eu.hansolo.fx:heatmap:17.0.23"
     implementation "eu.hansolo.fx:countries:17.0.33"
     implementation "ch.qos.logback:logback-classic:1.3.9"
+
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.3'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.3'
 }
 
 jar {
+    from {
+        //duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+        //configurations.runtimeClasspath.collect {  it.isDirectory() ? it : zipTree(it)  }
+    } {
+        exclude "META-INF/*.SF"
+        exclude "META-INF/*.DSA"
+        exclude "META-INF/*.RSA"
+    }
     manifest {
         attributes(
                 'Built-By'              : System.properties['user.name'],
@@ -62,7 +73,9 @@ jar {
                 'Bundle-License'        : 'https://www.apache.org/licenses/LICENSE-2.0;description=Apache License Version 2.0;link=https://spdx.org/licenses/Apache-2.0.html',
                 'Bundle-Description'    : description,
                 'Bundle-SymbolicName'   : 'eu.hansolo.fx.charts',
-                'Export-Package'        : 'eu.hansolo.fx.charts, eu.hansolo.fx.charts.data, eu.hansolo.fx.charts.event, eu.hansolo.fx.charts.series, eu.hansolo.fx.charts.tools, eu.hansolo.fx.charts.voronoi, eu.hansolo.fx.geometry, eu.hansolo.fx.geometry.tools, eu.hansolo.fx.geometry.transform'
+                'Export-Package'        : 'eu.hansolo.fx.geometry, eu.hansolo.fx.geometry.tools, eu.hansolo.fx.geometry.transform, eu.hansolo.fx.charts, eu.hansolo.fx.charts.areaheatmap, eu.hansolo.fx.charts.color, eu.hansolo.fx.charts.data, eu.hansolo.fx.charts.event, eu.hansolo.fx.charts.forcedirectedgraph, eu.hansolo.fx.charts.pareto, eu.hansolo.fx.charts.series, eu.hansolo.fx.charts.tools, eu.hansolo.fx.charts.world, eu.hansolo.fx.charts.voronoi, eu.hansolo.fx.charts.wafermap',
+                'Class-Path'            : "${project.name}-${project.version}.jar",
+                'Main-Class'            : 'eu.hansolo.fx.charts.Launcher'
         )
     }
 }

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -32,6 +32,7 @@ module eu.hansolo.fx.charts {
     opens eu.hansolo.fx.charts.tools to eu.hansolo.toolbox, eu.hansolo.toolboxfx, eu.hansolo.fx.heatmap, eu.hansolo.fx.countries;
     opens eu.hansolo.fx.charts.world to eu.hansolo.toolbox, eu.hansolo.toolboxfx, eu.hansolo.fx.heatmap, eu.hansolo.fx.countries;
     opens eu.hansolo.fx.charts.voronoi to eu.hansolo.toolbox, eu.hansolo.toolboxfx, eu.hansolo.fx.heatmap, eu.hansolo.fx.countries;
+    opens eu.hansolo.fx.charts.wafermap to eu.hansolo.toolbox, eu.hansolo.toolboxfx, eu.hansolo.fx.heatmap, eu.hansolo.fx.countries;
 
     exports eu.hansolo.fx.geometry;
     exports eu.hansolo.fx.geometry.tools;
@@ -48,5 +49,5 @@ module eu.hansolo.fx.charts {
     exports eu.hansolo.fx.charts.world;
     exports eu.hansolo.fx.charts.voronoi;
     exports eu.hansolo.fx.charts.wafermap;
-    opens eu.hansolo.fx.charts.wafermap to eu.hansolo.fx.countries, eu.hansolo.fx.heatmap, eu.hansolo.toolbox, eu.hansolo.toolboxfx;
+
 }


### PR DESCRIPTION
This is a follow on to HanSolo/charts#109

This PR is 4/4 in an attempt to fix the following error I was getting when performing jlink of [Birdasaur/Trinity](https://github.com/Birdasaur/Trinity) with the latest charts (17.1.47). Realized this propagated from toolbox all the way to charts, so I apolize for the bunch of PR's. Note charts, countries were failing to jlink as well.

The error looked something like this, but it got better as I kept adding missing opens/exports:
```
Module eu.hansolo.fx.countries contains package eu.hansolo.toolboxfx, module eu.hansolo.toolboxfx exports package eu.hansolo.toolboxfx to eu.hansolo.fx.countries
```

This one is mainly consistency fixes to match countries, toolboxfx, toolbox.

Edit (linking other PRs):
https://github.com/HanSolo/toolbox/pull/1
https://github.com/HanSolo/toolboxfx/pull/1
https://github.com/HanSolo/countries/pull/8
