### PR TITLE
Update GHA workflow to include jlink

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_KEY }}
           PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       - name: Build with Gradle
-        run: ./gradlew clean build jlink
+        run: ./gradlew clean build
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
@@ -44,4 +44,13 @@ jobs:
         with:
           name: Charts-${{ matrix.os }}
           path: ./build/libs/**
+      - name: Verify jlink
+        run: ./gradlew jlink
+        env:
+          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          GH_USER: ${{ secrets.GH_USER }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_KEY }}
+          PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 ...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,29 +9,29 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        java: [17.0.6]
+        java: [17.0.8]
       fail-fast: false
       max-parallel: 4
     name: Test JDK ${{ matrix.java }}, ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 17.0.6
+      - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v3
         with:
-          java-version: 17.0.6
+          java-version: ${{ matrix.java }}
           distribution: 'zulu'
       - name: Import GPG Key
         id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v3
+        uses: crazy-max/ghaction-import-gpg@v5
         with:
-          gpg-private-key: ${{ secrets.GPG_KEY }}
+          gpg_private_key: ${{ secrets.GPG_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_KEY }}
           PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       - name: Build with Gradle
-        run: ./gradlew clean build
+        run: ./gradlew clean build jlink
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
@@ -40,7 +40,7 @@ jobs:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_KEY }}
           PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Charts
           path: ./build/libs/**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,6 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
-          name: Charts
+          name: Charts-${{ matrix.os }}
           path: ./build/libs/**
 ...

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,6 @@
+import groovy.json.JsonOutput
+import groovy.json.JsonSlurper
+
 import java.text.SimpleDateFormat
 
 plugins {
@@ -132,6 +135,24 @@ signing {
 
     sign configurations.archives
     sign publishing.publications
+}
+
+// Remove 'thirdPartyCompatibility' from JavaFX runtimeElements variant
+// Otherwise it locks Gradle Module Metadata (GMM) to the publishing OS
+tasks.withType(GenerateModuleMetadata).configureEach {
+    doLast { _ ->
+        def gmmFile = it.outputFile.get().asFile
+        def inJson = new JsonSlurper().parseText(gmmFile.text)
+        def filteredVariant = inJson.variants.findAll { it.name == configurations.runtimeElements.name }
+        // remove "thirdPartyCompatibility" from GMM
+        filteredVariant.dependencies.first().each {
+            if (it.group == 'org.openjfx') {
+                it.remove('thirdPartyCompatibility')
+            }
+        }
+        def outJson = JsonOutput.toJson(inJson)
+        gmmFile.write(JsonOutput.prettyPrint(outJson))
+    }
 }
 
 publishing {

--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ dependencies {
 }
 
 application {
-    mainClass = "eu.hansolo.fx.charts.Demo"
+    mainClass = "eu.hansolo.fx.charts.Launcher"
     mainModule = moduleName
 }
 
@@ -86,7 +86,7 @@ jar {
                 'Bundle-SymbolicName'   : 'eu.hansolo.fx.charts',
                 'Export-Package'        : 'eu.hansolo.fx.geometry, eu.hansolo.fx.geometry.tools, eu.hansolo.fx.geometry.transform, eu.hansolo.fx.charts, eu.hansolo.fx.charts.areaheatmap, eu.hansolo.fx.charts.color, eu.hansolo.fx.charts.data, eu.hansolo.fx.charts.event, eu.hansolo.fx.charts.forcedirectedgraph, eu.hansolo.fx.charts.pareto, eu.hansolo.fx.charts.series, eu.hansolo.fx.charts.tools, eu.hansolo.fx.charts.world, eu.hansolo.fx.charts.voronoi, eu.hansolo.fx.charts.wafermap',
                 'Class-Path'            : "${project.name}-${project.version}.jar",
-                'Main-Class'            : 'eu.hansolo.fx.charts.Launcher'
+                'Main-Class'            : application.mainClass
         )
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -15,10 +15,11 @@ apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
 description   = 'Charts is a JavaFX library containing different kind of charts'
-mainClassName = "$moduleName/eu.hansolo.fx.charts.Demo"
+mainClassName = "$moduleName/eu.hansolo.fx.charts.Demo" // Deprecated: Old Gradle 6.4 Syntax
 
 Date buildTimeAndDate = new Date()
 ext {
+    moduleName      = 'eu.hansolo.fx.charts'
     buildDate       = new SimpleDateFormat('yyyy-MM-dd').format(buildTimeAndDate)
     buildTime       = new SimpleDateFormat('HH:mm:ss.SSSZ').format(buildTimeAndDate)
     platform        = osdetector.os == 'osx' ? osdetector.arch == 'aarch_64' ? 'mac-aarch64' : 'mac' : osdetector.os == 'windows' ? 'win' : osdetector.os == 'linux' ? osdetector.arch == 'aarch_64' ? 'linux-aarch64' : 'linux' : osdetector.os
@@ -47,6 +48,16 @@ dependencies {
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.3'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.3'
+}
+
+application {
+    mainClass = "eu.hansolo.fx.charts.Demo"
+    mainModule = moduleName
+}
+
+java {
+    // Set to false per https://github.com/java9-modularity/gradle-modules-plugin
+    modularity.inferModulePath.set(false)
 }
 
 jar {


### PR DESCRIPTION
The existing workflow has been updated to includes jlink testing as well. It also updates some of the actions versions and java version. Lastly it also includes some other changes/fixes I had locally but hadn't commited such as the java modularity plugin fixes.

Note: Merging this might cause jlink to fail until releases of the other packages are done from my last set of PR's 😅

Edit (08/13/2023): The gradle module metadata upstream in central seems to still reference `mac-aarch64`, [see example from central](https://repo1.maven.org/maven2/eu/hansolo/fx/charts/17.1.47/charts-17.1.47.module). jlink on the CI will fail with the following error as a result but will still work locally when using `repositories.mavenLocal()`.

```
Error: Two versions of module javafx.base found in /home/runner/work/charts/charts/build/jlinkbase/jlinkjars (javafx-base-20.0.2-linux.jar and javafx-base-20.0.2-mac-aarch64.jar)
```

I noticed the pom is edited via:

```
pom.withXml {
    asNode().dependencies.'*'.findAll {
        it.groupId.text() == 'org.openjfx'
    }.each {
        it.remove(it.classifier)
    }
}
```

My hunch is that [module.json](https://docs.gradle.org/current/userguide/publishing_gradle_module_metadata.html) also needs to be modified or not published.

Edit (08/16/2023): Following the advice from the [gradle slack community](https://gradle-community.slack.com/archives/CAHSN3LDN/p1692137622964049), I've updated build.gradle to remove the hardcoded platform os as part of `thirdPartyCompatibility` from the Gradle Module Metadata when publishing a package.

You can see how the resulting module file would look like in the my published one in the [github registry](https://github.com/samypr100/charts/packages/1923983)

Once a new release is made, the jlink job from the CI should start working.

Example of Working CI run (post publish): https://github.com/samypr100/charts/actions/runs/5882747525