### PR TITLE
streamline dependency/module graph

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,14 +39,11 @@ repositories {
 }
 
 dependencies {
+    api "eu.hansolo.fx:countries:17.0.35"
     implementation "org.openjfx:javafx-base:${javafxVersion}:${platform}"
     implementation "org.openjfx:javafx-graphics:${javafxVersion}:${platform}"
     implementation "org.openjfx:javafx-controls:${javafxVersion}:${platform}"
     implementation "org.openjfx:javafx-swing:${javafxVersion}:${platform}"
-    implementation "eu.hansolo:toolbox:17.0.55"
-    implementation "eu.hansolo:toolboxfx:17.0.45"
-    implementation "eu.hansolo.fx:heatmap:17.0.25"
-    implementation "eu.hansolo.fx:countries:17.0.35"
     implementation "ch.qos.logback:logback-classic:1.3.9"
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.3'

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -5,34 +5,31 @@ module eu.hansolo.fx.charts {
     requires java.logging;
 
     // Java-FX
-    requires transitive javafx.base;
-    requires transitive javafx.graphics;
-    requires transitive javafx.controls;
-    requires transitive javafx.swing;
+    requires javafx.base;
+    requires javafx.graphics;
+    requires javafx.controls;
+    requires javafx.swing;
 
     // 3rd party
     requires ch.qos.logback.classic;
     requires org.slf4j;
-    requires transitive eu.hansolo.toolbox;
-    requires transitive eu.hansolo.toolboxfx;
-    requires transitive eu.hansolo.fx.heatmap;
     requires transitive eu.hansolo.fx.countries;
 
-    opens eu.hansolo.fx.geometry to eu.hansolo.toolbox, eu.hansolo.toolboxfx, eu.hansolo.fx.heatmap, eu.hansolo.fx.countries;
-    opens eu.hansolo.fx.geometry.tools to eu.hansolo.toolbox, eu.hansolo.toolboxfx, eu.hansolo.fx.heatmap, eu.hansolo.fx.countries;
-    opens eu.hansolo.fx.geometry.transform to eu.hansolo.toolbox, eu.hansolo.toolboxfx, eu.hansolo.fx.heatmap, eu.hansolo.fx.countries;
-    opens eu.hansolo.fx.charts to eu.hansolo.toolbox, eu.hansolo.toolboxfx, eu.hansolo.fx.heatmap, eu.hansolo.fx.countries;
-    opens eu.hansolo.fx.charts.areaheatmap to eu.hansolo.toolbox, eu.hansolo.toolboxfx, eu.hansolo.fx.heatmap, eu.hansolo.fx.countries;
-    opens eu.hansolo.fx.charts.color to eu.hansolo.toolbox, eu.hansolo.toolboxfx, eu.hansolo.fx.heatmap, eu.hansolo.fx.countries;
-    opens eu.hansolo.fx.charts.data to eu.hansolo.toolbox, eu.hansolo.toolboxfx, eu.hansolo.fx.heatmap, eu.hansolo.fx.countries;
-    opens eu.hansolo.fx.charts.event to eu.hansolo.toolbox, eu.hansolo.toolboxfx, eu.hansolo.fx.heatmap, eu.hansolo.fx.countries;
-    opens eu.hansolo.fx.charts.forcedirectedgraph to eu.hansolo.toolbox, eu.hansolo.toolboxfx, eu.hansolo.fx.heatmap, eu.hansolo.fx.countries;
-    opens eu.hansolo.fx.charts.pareto to eu.hansolo.toolbox, eu.hansolo.toolboxfx, eu.hansolo.fx.heatmap, eu.hansolo.fx.countries;
-    opens eu.hansolo.fx.charts.series to eu.hansolo.toolbox, eu.hansolo.toolboxfx, eu.hansolo.fx.heatmap, eu.hansolo.fx.countries;
-    opens eu.hansolo.fx.charts.tools to eu.hansolo.toolbox, eu.hansolo.toolboxfx, eu.hansolo.fx.heatmap, eu.hansolo.fx.countries;
-    opens eu.hansolo.fx.charts.world to eu.hansolo.toolbox, eu.hansolo.toolboxfx, eu.hansolo.fx.heatmap, eu.hansolo.fx.countries;
-    opens eu.hansolo.fx.charts.voronoi to eu.hansolo.toolbox, eu.hansolo.toolboxfx, eu.hansolo.fx.heatmap, eu.hansolo.fx.countries;
-    opens eu.hansolo.fx.charts.wafermap to eu.hansolo.toolbox, eu.hansolo.toolboxfx, eu.hansolo.fx.heatmap, eu.hansolo.fx.countries;
+    opens eu.hansolo.fx.geometry to eu.hansolo.fx.countries;
+    opens eu.hansolo.fx.geometry.tools to eu.hansolo.fx.countries;
+    opens eu.hansolo.fx.geometry.transform to eu.hansolo.fx.countries;
+    opens eu.hansolo.fx.charts to eu.hansolo.fx.countries;
+    opens eu.hansolo.fx.charts.areaheatmap to eu.hansolo.fx.countries;
+    opens eu.hansolo.fx.charts.color to eu.hansolo.fx.countries;
+    opens eu.hansolo.fx.charts.data to eu.hansolo.fx.countries;
+    opens eu.hansolo.fx.charts.event to eu.hansolo.fx.countries;
+    opens eu.hansolo.fx.charts.forcedirectedgraph to eu.hansolo.fx.countries;
+    opens eu.hansolo.fx.charts.pareto to eu.hansolo.fx.countries;
+    opens eu.hansolo.fx.charts.series to eu.hansolo.fx.countries;
+    opens eu.hansolo.fx.charts.tools to eu.hansolo.fx.countries;
+    opens eu.hansolo.fx.charts.world to eu.hansolo.fx.countries;
+    opens eu.hansolo.fx.charts.voronoi to eu.hansolo.fx.countries;
+    opens eu.hansolo.fx.charts.wafermap to eu.hansolo.fx.countries;
 
     exports eu.hansolo.fx.geometry;
     exports eu.hansolo.fx.geometry.tools;


### PR DESCRIPTION
PR 4/4

This will help streamline the dependency graph across dependencies by using api configuration per gradle [docs](https://docs.gradle.org/current/userguide/java_library_plugin.html#declaring_module_dependencies).

This allows the end user to only have to type `implementation 'eu.hansolo.fx:charts:17.1.49'` to get all the needed dependencies.

![dg-charts](https://github.com/HanSolo/charts/assets/3933065/bdc06967-f4e4-4b1e-ac92-a54680c367ed)

Note: CI will fail until a release of `countries` is made after https://github.com/HanSolo/countries/pull/10