### PR TITLE
Add Bundle-Version to Manifest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,6 +80,7 @@ jar {
                 'Implementation-Title'  : project.name,
                 'Implementation-Version': project.version,
                 'Bundle-Name'           : project.name,
+                'Bundle-Version'        : project.version,
                 'Bundle-License'        : 'https://www.apache.org/licenses/LICENSE-2.0;description=Apache License Version 2.0;link=https://spdx.org/licenses/Apache-2.0.html',
                 'Bundle-Description'    : project.description,
                 'Bundle-SymbolicName'   : 'eu.hansolo.fx.charts',


### PR DESCRIPTION
This pull request enhances the Gradle build script by adding the Bundle-Version attribute to the Manifest file. This change is necessary for compatibility with Apache Ivy (Version 2.5.2), which parses the Bundle-Version to determine dependency versions.