### PR TITLE
Make logback module optional in module-info.java

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -11,7 +11,7 @@ module eu.hansolo.fx.charts {
     requires javafx.swing;
 
     // 3rd party
-    requires ch.qos.logback.classic;
+    requires static ch.qos.logback.classic;
     requires org.slf4j;
     requires transitive eu.hansolo.fx.countries;
 


### PR DESCRIPTION
Changes `ch.qos.logback.classic` to be optional to avoid downstream consumer errors such as `Module ch.qos.logback.classic not found, required by eu.hansolo.fx.charts`

This change has no side-effects since logback is not imported directly in charts and it's only used as a logging backend. It makes logback optional from a module perspective on downstream consumers of the library.